### PR TITLE
Fix download_file to use self._client.download_file

### DIFF
--- a/drive/files.py
+++ b/drive/files.py
@@ -225,7 +225,7 @@ class File:
         """
         if not self._client:
             return False
-        return self._client.download(self.id, path, mime_type=mime_type)
+        return self._client.download_file(self.id, path, mime_type=mime_type)
 
     def download_workbook(self):
         """


### PR DESCRIPTION
There's a bug when using download_file that causes an attribute error when passing the path as a writer. To correct this, we need to use the correct function for the client so the arguments are passed properly.